### PR TITLE
fix: stage was wrong on "unknown" badges

### DIFF
--- a/templates/template.html.j2
+++ b/templates/template.html.j2
@@ -40,7 +40,7 @@
                                     {%- if stage in val[release].keys() %}
                                         <a href="{{val[release][stage]['url']}}"><img src="{{val[release][stage]['badge']}}" alt="{{val[release][stage]['text']}}"/></a>
                                     {%- else %}
-                                    <img src="build_unknown.svg" alt="Unknown"/>
+                                    <img src="{{stage}}_unknown.svg" alt="Unknown"/>
                                     {%- endif %}
                                 {%- endfor %}
                             {%- else %}


### PR DESCRIPTION
When a given job is not found in a pipeline, an "unknown" badge is displayed in the report. However, the "build" unknown badge was always used. This fix displays the badge for the correct stage. 